### PR TITLE
Redesign portfolio as infinite canvas with section overlays

### DIFF
--- a/.claude/IMPLEMENTATION_SUMMARY.md
+++ b/.claude/IMPLEMENTATION_SUMMARY.md
@@ -1,5 +1,60 @@
 # Digital Garden Implementation Summary
 
+---
+
+## 🟢 Current State (as of March 2026)
+
+The project has been **fully redesigned** from the phases below into an **infinite canvas portfolio**. The canvas-based design is live on `main`. The below phases (1–8) describe historical work on a `redesign` branch that was superseded.
+
+### Architecture Overview
+
+**Stack:** SvelteKit + Svelte 5, TypeScript, deployed to GitHub Pages
+**Entry point:** `src/routes/+page.svelte`
+**Key stores:** `src/lib/stores/canvas.ts` — `navigateFn`, `locked`, `activeSection`
+
+#### How navigation works
+- `Canvas.svelte` renders an infinite panning canvas (no manual zoom — zoom is purely programmatic).
+- On load, canvas centers on the `about` frame position.
+- Clicking a section preview card calls `navigateFn(id)`, which:
+  1. Animates `scale` to `min(vw/frameW, vh/frameH)` to zoom-fill the viewport (500ms cubic-bezier transition).
+  2. Sets `activeSection` → triggers a full-screen fixed overlay for that section.
+  3. Sets `locked = true` (disables canvas drag).
+- Clicking **← Home** calls `navigateFn('about')`, which resets scale to 1 and clears `activeSection`/`locked`.
+
+#### Overlay architecture (critical)
+`position: fixed` inside a CSS-transformed element does **not** anchor to the viewport (the transform creates a new containing block). All overlays are therefore rendered **outside** `Canvas.svelte` directly in `+page.svelte`:
+
+- **About overlay** — always mounted, fades out when `$locked`. `pointer-events: none` on the container so the canvas is pannable through the bio; `pointer-events: auto` on `.bio` so buttons/links work.
+- **Section overlays** — one `{#if}` block per section (portfolio/garden/links), each with `transition:fade`. Full-screen, `overflow-x: auto; overflow-y: hidden`, `scroll-snap-type: x mandatory`. A `use:hscroll` action converts vertical wheel events to horizontal scroll.
+
+#### Key components
+
+| File | Role |
+|------|------|
+| `src/routes/+page.svelte` | Root: all overlays + canvas with Frame preview cards |
+| `src/lib/components/Canvas.svelte` | Infinite pan canvas; programmatic zoom on navigate |
+| `src/lib/components/Frame.svelte` | Preview card in canvas space (no children/fixed props) |
+| `src/lib/components/Bio.svelte` | About content; `width: min(580px, calc(100vw - 5rem))` |
+| `src/lib/components/Portfolio.svelte` | Horizontal scroll panels (image 55% / info 45%) |
+| `src/lib/components/Header.svelte` | Fixed top bar with nav shape buttons |
+
+#### Canvas frame positions (defined in `+page.svelte`)
+```ts
+about:     { x: -300, y: -200, width: 600,  height: 400 }
+portfolio: { x: 1100, y: -250, width: 740,  height: 650 }
+garden:    { x: -300, y:  350, width: 600,  height: 400 }
+links:     { x: -1700,y: -200, width: 480,  height: 380 }
+```
+
+#### What's still TODO / known gaps
+- **Garden section** — currently shows "coming soon." Needs real content wired up.
+- **Links section** — hardcoded list of 3 links; should pull from data.
+- **Mobile UX** — not thoroughly tested; touch panning works but section overlays may need padding adjustments.
+- **Header nav** — shape buttons exist but their exact IDs/behavior should be verified match section IDs.
+- **Portfolio data** — comes from `+page.ts` loader (`data.works`); verify images and links are correct.
+
+---
+
 ## ✅ Completed Phases (1-8)
 
 ### Phase 1: Foundation & Setup

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .svelte-kit
 node_modules
+.vercel

--- a/src/app.css
+++ b/src/app.css
@@ -1,3 +1,6 @@
-*, *::before, *::after { box-sizing: border-box; }
+*, *::before, *::after {
+  box-sizing: border-box;
+  cursor: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10'%3E%3Ccircle cx='5' cy='5' r='4' fill='%231a1a1a'/%3E%3C/svg%3E") 5 5, auto !important;
+}
 body { margin: 0; padding: 0; overflow: hidden; -webkit-font-smoothing: antialiased; }
 button { -webkit-tap-highlight-color: transparent; }

--- a/src/app.css
+++ b/src/app.css
@@ -1,0 +1,3 @@
+*, *::before, *::after { box-sizing: border-box; }
+body { margin: 0; padding: 0; overflow: hidden; -webkit-font-smoothing: antialiased; }
+button { -webkit-tap-highlight-color: transparent; }

--- a/src/lib/components/Bio.svelte
+++ b/src/lib/components/Bio.svelte
@@ -43,6 +43,7 @@
   .bio {
     font-family: Montserrat, sans-serif;
     width: min(580px, calc(100vw - 5rem));
+    pointer-events: auto;
   }
 
   .bio-top {

--- a/src/lib/components/Bio.svelte
+++ b/src/lib/components/Bio.svelte
@@ -3,44 +3,78 @@
 </script>
 
 <div class="bio">
-  <h1 class="name">Marcus Lee</h1>
+  <div class="bio-top">
+    <h1 class="name">Marcus Lee</h1>
+    <p class="tagline">Computer Science · Williams College</p>
+  </div>
+
+  <hr class="divider" />
+
   <p class="body">
-    A student pursuing his BA in Computer Science at Williams College. His work spans distributed systems, automated cloud infrastructure, and frontend design. Currently exploring thoughtful AI tooling for students and decentralized economies—
-    <a target="_blank" rel="noopener noreferrer" href="https://medium.com/design-bootcamp/we-love-automation-but-hate-ai-what-ux-teaches-us-about-control-and-trust-c2f41c29906b">building software for people that makes them feel empowered and in control.</a>
-    Between Kubernetes and Svelte, he'll always welcome a conversation over a lightly-brewed cup of tea.
+    A student pursuing his BA in Computer Science at Williams College. His work spans distributed
+    systems, automated cloud infrastructure, and frontend design. Currently exploring thoughtful AI
+    tooling for students and decentralized economies —
+    <a
+      target="_blank"
+      rel="noopener noreferrer"
+      href="https://medium.com/design-bootcamp/we-love-automation-but-hate-ai-what-ux-teaches-us-about-control-and-trust-c2f41c29906b"
+      >building software for people that makes them feel empowered and in control.</a
+    >
+    Between Kubernetes and Svelte, he'll always welcome a conversation over a lightly-brewed cup of
+    tea.
   </p>
+
   <div class="actions">
-    <button onclick={() => $navigateFn?.('portfolio')}>→ See my work</button>
-    <button onclick={() => $navigateFn?.('garden')}>→ Read my writing</button>
+    <button onclick={() => $navigateFn?.('portfolio')}>→ Work</button>
+    <button onclick={() => $navigateFn?.('garden')}>→ Garden</button>
     <button onclick={() => $navigateFn?.('links')}>→ Links</button>
   </div>
-  <div class="social">
-    <a target="_blank" rel="noopener noreferrer" href="https://www.linkedin.com/in/marcusnglee">LinkedIn</a>
-    <a target="_blank" rel="noopener noreferrer" href="https://www.github.com/marcusnglee">GitHub</a>
+
+  <div class="footer">
+    <div class="social">
+      <a target="_blank" rel="noopener noreferrer" href="https://www.linkedin.com/in/marcusnglee">LinkedIn</a>
+      <a target="_blank" rel="noopener noreferrer" href="https://www.github.com/marcusnglee">GitHub</a>
+    </div>
+    <p class="hint">feel free to browse around!</p>
   </div>
-  <p class="hint">feel free to browse around!</p>
 </div>
 
 <style>
   .bio {
-    padding: 2.5rem;
     font-family: Montserrat, sans-serif;
-    max-width: 520px;
-    width: 100%;
+    width: min(580px, calc(100vw - 5rem));
+  }
+
+  .bio-top {
+    margin-bottom: 1.5rem;
   }
 
   .name {
-    font-size: 2rem;
+    font-size: clamp(1.8rem, 4vw, 2.75rem);
     font-weight: 700;
     color: #1a1a1a;
-    margin: 0 0 1.25rem;
+    margin: 0 0 0.4rem;
     letter-spacing: -0.03em;
+    line-height: 1.1;
+  }
+
+  .tagline {
+    font-size: 0.8rem;
+    color: #aaa;
+    margin: 0;
+    letter-spacing: 0.04em;
+  }
+
+  .divider {
+    border: none;
+    border-top: 1px solid #e0dbd3;
+    margin: 0 0 1.5rem;
   }
 
   .body {
     font-size: 0.9rem;
     color: #555;
-    line-height: 1.8;
+    line-height: 1.85;
     margin: 0 0 1.75rem;
   }
 
@@ -59,8 +93,8 @@
 
   .actions {
     display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
+    gap: 1.5rem;
+    flex-wrap: wrap;
     margin-bottom: 1.75rem;
   }
 
@@ -72,14 +106,20 @@
     font-size: 0.875rem;
     font-weight: 600;
     color: #555;
-    cursor: pointer;
-    text-align: left;
     transition: color 0.15s ease;
     letter-spacing: 0.01em;
   }
 
   .actions button:hover {
     color: #1a1a1a;
+  }
+
+  .footer {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 0.75rem;
   }
 
   .social {
@@ -104,7 +144,7 @@
   .hint {
     font-size: 0.75rem;
     color: #bbb;
-    margin: 1rem 0 0;
+    margin: 0;
     font-style: italic;
   }
 </style>

--- a/src/lib/components/Bio.svelte
+++ b/src/lib/components/Bio.svelte
@@ -18,6 +18,7 @@
     <a target="_blank" rel="noopener noreferrer" href="https://www.linkedin.com/in/marcusnglee">LinkedIn</a>
     <a target="_blank" rel="noopener noreferrer" href="https://www.github.com/marcusnglee">GitHub</a>
   </div>
+  <p class="hint">feel free to browse around!</p>
 </div>
 
 <style>
@@ -96,5 +97,12 @@
   .social a:hover {
     color: #1a1a1a;
     border-color: #1a1a1a;
+  }
+
+  .hint {
+    font-size: 0.75rem;
+    color: #bbb;
+    margin: 1rem 0 0;
+    font-style: italic;
   }
 </style>

--- a/src/lib/components/Bio.svelte
+++ b/src/lib/components/Bio.svelte
@@ -25,6 +25,8 @@
   .bio {
     padding: 2.5rem;
     font-family: Montserrat, sans-serif;
+    max-width: 520px;
+    width: 100%;
   }
 
   .name {

--- a/src/lib/components/Bio.svelte
+++ b/src/lib/components/Bio.svelte
@@ -1,45 +1,100 @@
-<script lang='ts'>
-
+<script lang="ts">
+  import { navigateFn } from '$lib/stores/canvas';
 </script>
 
-<div class='bio'>
-    <div class="paragraph">
-    <p>
-        <span class="name"><strong>Marcus Lee</strong></span> is a student pursuing his BA in Computer Science at Williams College. His work spans distributed systems, automated cloud infrastructure, and frontend design. Currently, he's exploring thoughtful AI tooling for students and decentralized economies—
-        <a target="_blank" rel="noopener noref" href="https://medium.com/design-bootcamp/we-love-automation-but-hate-ai-what-ux-teaches-us-about-control-and-trust-c2f41c29906b"><u>building software for people that makes them feel empowered and in control.</u></a> Between Kubernetes and Svelte, he'll always welcome another to conversation over a lightly-brewed cup of tea. This is also the only time Marcus will describe himself in the 3rd person.
-    </p>
-</div>
-    <div class='links'>
-        <a target="_blank" rel="noopener noref" href="https://www.linkedin.com/in/marcusnglee">linkedin.com/in/marcusnglee</a>
-        <a target="_blank" rel="noopener noref" href="https://www.github.com/marcusnglee">github.com/marcusnglee</a>
-
-    </div>
+<div class="bio">
+  <h1 class="name">Marcus Lee</h1>
+  <p class="body">
+    A student pursuing his BA in Computer Science at Williams College. His work spans distributed systems, automated cloud infrastructure, and frontend design. Currently exploring thoughtful AI tooling for students and decentralized economies—
+    <a target="_blank" rel="noopener noreferrer" href="https://medium.com/design-bootcamp/we-love-automation-but-hate-ai-what-ux-teaches-us-about-control-and-trust-c2f41c29906b">building software for people that makes them feel empowered and in control.</a>
+    Between Kubernetes and Svelte, he'll always welcome a conversation over a lightly-brewed cup of tea.
+  </p>
+  <div class="actions">
+    <button onclick={() => $navigateFn?.('portfolio')}>→ See my work</button>
+    <button onclick={() => $navigateFn?.('garden')}>→ Read my writing</button>
+    <button onclick={() => $navigateFn?.('links')}>→ Links</button>
+  </div>
+  <div class="social">
+    <a target="_blank" rel="noopener noreferrer" href="https://www.linkedin.com/in/marcusnglee">LinkedIn</a>
+    <a target="_blank" rel="noopener noreferrer" href="https://www.github.com/marcusnglee">GitHub</a>
+  </div>
 </div>
 
 <style>
-.name {
-    color: black;
-    font-family: Montserrat;
-}
-.bio {
-    line-height: 2;
-    font-family: Montserrat;
-    font-size: medium;
-    color: rgb(113, 113, 113);
-}
-.paragraph a{
-    color: rgb(113, 113, 113);
-    transition: color 0.2s ease;
-}
-.paragraph a:hover{
-    color: rgb(59, 51, 51);   
-}
-.links a{
-    color: rgb(59, 51, 51);   
-    padding: 0rem 1rem; 
-}
-.links {
-    align-items: center;
-    padding-bottom: 2rem;
-}
+  .bio {
+    padding: 2.5rem;
+    font-family: Montserrat, sans-serif;
+  }
+
+  .name {
+    font-size: 2rem;
+    font-weight: 700;
+    color: #1a1a1a;
+    margin: 0 0 1.25rem;
+    letter-spacing: -0.03em;
+  }
+
+  .body {
+    font-size: 0.9rem;
+    color: #555;
+    line-height: 1.8;
+    margin: 0 0 1.75rem;
+  }
+
+  .body a {
+    color: #555;
+    text-decoration: none;
+    border-bottom: 1px solid #c8c3b8;
+    padding-bottom: 1px;
+    transition: color 0.15s ease, border-color 0.15s ease;
+  }
+
+  .body a:hover {
+    color: #1a1a1a;
+    border-color: #1a1a1a;
+  }
+
+  .actions {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    margin-bottom: 1.75rem;
+  }
+
+  .actions button {
+    background: none;
+    border: none;
+    padding: 0;
+    font-family: Montserrat, sans-serif;
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: #555;
+    cursor: pointer;
+    text-align: left;
+    transition: color 0.15s ease;
+    letter-spacing: 0.01em;
+  }
+
+  .actions button:hover {
+    color: #1a1a1a;
+  }
+
+  .social {
+    display: flex;
+    gap: 1.25rem;
+  }
+
+  .social a {
+    font-size: 0.8rem;
+    color: #888;
+    text-decoration: none;
+    border-bottom: 1px solid #e0dbd3;
+    padding-bottom: 1px;
+    transition: color 0.15s ease, border-color 0.15s ease;
+  }
+
+  .social a:hover {
+    color: #1a1a1a;
+    border-color: #1a1a1a;
+  }
 </style>

--- a/src/lib/components/Canvas.svelte
+++ b/src/lib/components/Canvas.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
-	import { navigateFn, locked } from '$lib/stores/canvas';
+	import { navigateFn, locked, activeSection } from '$lib/stores/canvas';
 	import type { Snippet } from 'svelte';
 
 	interface FramePos {
@@ -134,6 +134,7 @@
 		tx = vw / 2 - (frame.x + frame.width / 2) * scale;
 		ty = vh / 2 - (frame.y + frame.height / 2) * scale;
 		locked.set(id !== 'about');
+		activeSection.set(id === 'about' ? null : id);
 		setTimeout(() => {
 			isAnimating = false;
 		}, 560);
@@ -165,6 +166,7 @@
 		return () => {
 			navigateFn.set(null);
 			locked.set(false);
+			activeSection.set(null);
 			window.removeEventListener('mousemove', onGlobalMouseMove);
 			window.removeEventListener('mouseup', onGlobalMouseUp);
 			viewportEl.removeEventListener('wheel', handleWheel);
@@ -202,12 +204,7 @@
 		background-color: #f8f6f1;
 		user-select: none;
 		-webkit-user-select: none;
-		cursor: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10'%3E%3Ccircle cx='5' cy='5' r='4' fill='%231a1a1a'/%3E%3C/svg%3E") 5 5, auto;
 		outline: none;
-	}
-
-	.viewport.locked {
-		cursor: default;
 	}
 
 	.canvas-inner {

--- a/src/lib/components/Canvas.svelte
+++ b/src/lib/components/Canvas.svelte
@@ -26,14 +26,8 @@
 
 	let viewportEl: HTMLDivElement;
 
-	const MIN_SCALE = 0.2;
-	const MAX_SCALE = 3;
-
 	let lastMouseX = 0;
 	let lastMouseY = 0;
-	let lastTouchDist = 0;
-	let lastTouchMidX = 0;
-	let lastTouchMidY = 0;
 
 	function startDrag(e: MouseEvent) {
 		if ($locked) return;
@@ -60,32 +54,14 @@
 	function handleWheel(e: WheelEvent) {
 		e.preventDefault();
 		if ($locked) return;
-		if (e.ctrlKey || e.metaKey) {
-			// Pinch-to-zoom (trackpad) or ctrl+scroll
-			const delta = -e.deltaY * 0.005;
-			const factor = Math.exp(delta * 2);
-			const newScale = Math.min(MAX_SCALE, Math.max(MIN_SCALE, scale * factor));
-			const ratio = newScale / scale;
-			tx = e.clientX - ratio * (e.clientX - tx);
-			ty = e.clientY - ratio * (e.clientY - ty);
-			scale = newScale;
-		} else {
-			// Pan
-			tx -= e.deltaX;
-			ty -= e.deltaY;
-		}
+		// Pan only — zoom is programmatic via navigateTo
+		tx -= e.deltaX;
+		ty -= e.deltaY;
 	}
 
 	function handleTouchStart(e: TouchEvent) {
 		if ($locked) return;
-		if (e.touches.length === 2) {
-			const t1 = e.touches[0];
-			const t2 = e.touches[1];
-			lastTouchDist = Math.hypot(t2.clientX - t1.clientX, t2.clientY - t1.clientY);
-			lastTouchMidX = (t1.clientX + t2.clientX) / 2;
-			lastTouchMidY = (t1.clientY + t2.clientY) / 2;
-			isDragging = false;
-		} else if (e.touches.length === 1) {
+		if (e.touches.length === 1) {
 			const target = e.touches[0].target as HTMLElement;
 			if (target.closest('button, a, input, textarea, select')) return;
 			lastMouseX = e.touches[0].clientX;
@@ -97,23 +73,7 @@
 	function handleTouchMove(e: TouchEvent) {
 		e.preventDefault();
 		if ($locked) return;
-		if (e.touches.length === 2) {
-			isDragging = false;
-			const t1 = e.touches[0];
-			const t2 = e.touches[1];
-			const dist = Math.hypot(t2.clientX - t1.clientX, t2.clientY - t1.clientY);
-			const midX = (t1.clientX + t2.clientX) / 2;
-			const midY = (t1.clientY + t2.clientY) / 2;
-			const zoomFactor = dist / lastTouchDist;
-			const newScale = Math.min(MAX_SCALE, Math.max(MIN_SCALE, scale * zoomFactor));
-			const ratio = newScale / scale;
-			tx = midX - ratio * (midX - tx) + (midX - lastTouchMidX);
-			ty = midY - ratio * (midY - ty) + (midY - lastTouchMidY);
-			scale = newScale;
-			lastTouchDist = dist;
-			lastTouchMidX = midX;
-			lastTouchMidY = midY;
-		} else if (e.touches.length === 1 && isDragging) {
+		if (e.touches.length === 1 && isDragging) {
 			tx += e.touches[0].clientX - lastMouseX;
 			ty += e.touches[0].clientY - lastMouseY;
 			lastMouseX = e.touches[0].clientX;
@@ -131,8 +91,14 @@
 		const vw = window.innerWidth;
 		const vh = window.innerHeight;
 		isAnimating = true;
-		tx = vw / 2 - (frame.x + frame.width / 2) * scale;
-		ty = vh / 2 - (frame.y + frame.height / 2) * scale;
+
+		// Zoom to fill viewport for sections; reset to 1 for about
+		const newScale =
+			id === 'about' ? 1 : Math.min(vw / frame.width, vh / frame.height);
+		tx = vw / 2 - (frame.x + frame.width / 2) * newScale;
+		ty = vh / 2 - (frame.y + frame.height / 2) * newScale;
+		scale = newScale;
+
 		locked.set(id !== 'about');
 		activeSection.set(id === 'about' ? null : id);
 		setTimeout(() => {
@@ -141,7 +107,6 @@
 	}
 
 	onMount(() => {
-		// Center on the about frame
 		const vw = window.innerWidth;
 		const vh = window.innerHeight;
 		const aboutFrame = framePositions['about'];
@@ -150,14 +115,11 @@
 			ty = vh / 2 - (aboutFrame.y + aboutFrame.height / 2);
 		}
 
-		// Register navigate function in store
 		navigateFn.set(navigateTo);
 
-		// Global mouse listeners for drag
 		window.addEventListener('mousemove', onGlobalMouseMove);
 		window.addEventListener('mouseup', onGlobalMouseUp);
 
-		// Non-passive wheel and touch listeners
 		viewportEl.addEventListener('wheel', handleWheel, { passive: false });
 		viewportEl.addEventListener('touchstart', handleTouchStart, { passive: false });
 		viewportEl.addEventListener('touchmove', handleTouchMove, { passive: false });
@@ -181,7 +143,6 @@
 <div
 	bind:this={viewportEl}
 	class="viewport"
-	class:locked={$locked}
 	onmousedown={startDrag}
 	role="application"
 	aria-label="Infinite canvas"

--- a/src/lib/components/Canvas.svelte
+++ b/src/lib/components/Canvas.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
-	import { navigateFn } from '$lib/stores/canvas';
+	import { navigateFn, locked } from '$lib/stores/canvas';
 	import type { Snippet } from 'svelte';
 
 	interface FramePos {
@@ -26,7 +26,6 @@
 
 	let viewportEl: HTMLDivElement;
 
-	const GRID_SIZE = 24;
 	const MIN_SCALE = 0.2;
 	const MAX_SCALE = 3;
 
@@ -36,18 +35,8 @@
 	let lastTouchMidX = 0;
 	let lastTouchMidY = 0;
 
-	// Update dot grid CSS custom properties whenever transform changes
-	$effect(() => {
-		if (!viewportEl) return;
-		const gs = GRID_SIZE * scale;
-		const ox = ((tx % gs) + gs) % gs;
-		const oy = ((ty % gs) + gs) % gs;
-		viewportEl.style.setProperty('--dot-ox', `${ox}px`);
-		viewportEl.style.setProperty('--dot-oy', `${oy}px`);
-		viewportEl.style.setProperty('--dot-size', `${gs}px`);
-	});
-
 	function startDrag(e: MouseEvent) {
+		if ($locked) return;
 		if (e.button !== 0) return;
 		const target = e.target as HTMLElement;
 		if (target.closest('button, a, input, textarea, select')) return;
@@ -70,6 +59,7 @@
 
 	function handleWheel(e: WheelEvent) {
 		e.preventDefault();
+		if ($locked) return;
 		if (e.ctrlKey || e.metaKey) {
 			// Pinch-to-zoom (trackpad) or ctrl+scroll
 			const delta = -e.deltaY * 0.005;
@@ -87,6 +77,7 @@
 	}
 
 	function handleTouchStart(e: TouchEvent) {
+		if ($locked) return;
 		if (e.touches.length === 2) {
 			const t1 = e.touches[0];
 			const t2 = e.touches[1];
@@ -105,6 +96,7 @@
 
 	function handleTouchMove(e: TouchEvent) {
 		e.preventDefault();
+		if ($locked) return;
 		if (e.touches.length === 2) {
 			isDragging = false;
 			const t1 = e.touches[0];
@@ -141,6 +133,7 @@
 		isAnimating = true;
 		tx = vw / 2 - (frame.x + frame.width / 2) * scale;
 		ty = vh / 2 - (frame.y + frame.height / 2) * scale;
+		locked.set(id !== 'about');
 		setTimeout(() => {
 			isAnimating = false;
 		}, 560);
@@ -171,6 +164,7 @@
 
 		return () => {
 			navigateFn.set(null);
+			locked.set(false);
 			window.removeEventListener('mousemove', onGlobalMouseMove);
 			window.removeEventListener('mouseup', onGlobalMouseUp);
 			viewportEl.removeEventListener('wheel', handleWheel);
@@ -185,7 +179,7 @@
 <div
 	bind:this={viewportEl}
 	class="viewport"
-	class:dragging={isDragging}
+	class:locked={$locked}
 	onmousedown={startDrag}
 	role="application"
 	aria-label="Infinite canvas"
@@ -206,17 +200,14 @@
 		inset: 0;
 		overflow: hidden;
 		background-color: #f8f6f1;
-		background-image: radial-gradient(circle, #c8c3b8 1.5px, transparent 1.5px);
-		background-size: var(--dot-size, 24px) var(--dot-size, 24px);
-		background-position: var(--dot-ox, 0px) var(--dot-oy, 0px);
 		user-select: none;
 		-webkit-user-select: none;
-		cursor: grab;
+		cursor: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10'%3E%3Ccircle cx='5' cy='5' r='4' fill='%231a1a1a'/%3E%3C/svg%3E") 5 5, auto;
 		outline: none;
 	}
 
-	.viewport.dragging {
-		cursor: grabbing;
+	.viewport.locked {
+		cursor: default;
 	}
 
 	.canvas-inner {

--- a/src/lib/components/Frame.svelte
+++ b/src/lib/components/Frame.svelte
@@ -8,6 +8,9 @@
 		y,
 		width,
 		label,
+		fixed = false,
+		dark = false,
+		background,
 		children
 	}: {
 		id?: string;
@@ -15,38 +18,78 @@
 		y: number;
 		width?: number;
 		label?: string;
+		fixed?: boolean;
+		dark?: boolean;
+		background?: string;
 		children: Snippet;
 	} = $props();
 
 	let isRevealed = $derived(id === 'about' || $activeSection === id);
 </script>
 
-{#if label}
+{#if fixed}
+	<!-- Full-screen overlay for the about/landing frame -->
 	<div
-		class="frame-label"
-		style="left: {x}px; top: {y - 22}px; {width ? `width: ${width}px;` : ''}"
+		{id}
+		class="frame-fullscreen"
+		class:hiding={$locked}
+		style={background ? `background: ${background};` : ''}
 	>
-		{label}
+		{@render children()}
+	</div>
+{:else}
+	{#if label}
+		<div
+			class="frame-label"
+			style="left: {x}px; top: {y - 22}px; {width ? `width: ${width}px;` : ''}"
+		>
+			{label}
+		</div>
+	{/if}
+
+	<div
+		{id}
+		class="frame"
+		class:dark
+		style="left: {x}px; top: {y}px; {width ? `width: ${width}px;` : ''}{background ? ` background: ${background};` : ''}"
+	>
+		{#if isRevealed}
+			{@render children()}
+			{#if $locked && id !== 'about'}
+				<div class="home-bar">
+					<button class="home-btn" onclick={() => $navigateFn?.('about')}>← Home</button>
+				</div>
+			{/if}
+		{:else}
+			<button class="preview" onclick={() => $navigateFn?.(id ?? '')}>
+				<span class="preview-label">{label}</span>
+				<span class="preview-hint">enter →</span>
+			</button>
+		{/if}
 	</div>
 {/if}
 
-<div {id} class="frame" style="left: {x}px; top: {y}px; {width ? `width: ${width}px;` : ''}">
-	{#if isRevealed}
-		{@render children()}
-		{#if $locked && id !== 'about'}
-			<div class="home-bar">
-				<button class="home-btn" onclick={() => $navigateFn?.('about')}>← Home</button>
-			</div>
-		{/if}
-	{:else}
-		<button class="preview" onclick={() => $navigateFn?.(id ?? '')}>
-			<span class="preview-label">{label}</span>
-			<span class="preview-hint">enter →</span>
-		</button>
-	{/if}
-</div>
-
 <style>
+	/* ── Fixed full-screen frame (About / landing) ── */
+	.frame-fullscreen {
+		position: fixed;
+		inset: 0;
+		z-index: 50;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		background: #f8f6f1;
+		opacity: 1;
+		pointer-events: auto;
+		transition: opacity 0.35s ease;
+	}
+
+	.frame-fullscreen.hiding {
+		opacity: 0;
+		pointer-events: none;
+	}
+
+	/* ── Canvas card frame ── */
 	.frame {
 		position: absolute;
 		background: #fff;
@@ -55,6 +98,13 @@
 		box-shadow:
 			0 4px 24px rgba(0, 0, 0, 0.06),
 			0 1px 4px rgba(0, 0, 0, 0.04);
+	}
+
+	.frame.dark {
+		border-color: rgba(255, 255, 255, 0.08);
+		box-shadow:
+			0 4px 24px rgba(0, 0, 0, 0.3),
+			0 1px 4px rgba(0, 0, 0, 0.15);
 	}
 
 	.frame-label {
@@ -68,6 +118,7 @@
 		user-select: none;
 	}
 
+	/* ── Preview gateway button ── */
 	.preview {
 		display: flex;
 		flex-direction: column;
@@ -84,7 +135,11 @@
 	}
 
 	.preview:hover {
-		background: #faf8f4;
+		background: rgba(0, 0, 0, 0.03);
+	}
+
+	.dark .preview:hover {
+		background: rgba(255, 255, 255, 0.06);
 	}
 
 	.preview-label {
@@ -95,6 +150,10 @@
 		letter-spacing: -0.02em;
 	}
 
+	.dark .preview-label {
+		color: rgba(255, 255, 255, 0.88);
+	}
+
 	.preview-hint {
 		font-family: Montserrat, sans-serif;
 		font-size: 0.75rem;
@@ -103,13 +162,26 @@
 		transition: color 0.15s ease;
 	}
 
+	.dark .preview-hint {
+		color: rgba(255, 255, 255, 0.3);
+	}
+
 	.preview:hover .preview-hint {
 		color: #888;
 	}
 
+	.dark .preview:hover .preview-hint {
+		color: rgba(255, 255, 255, 0.6);
+	}
+
+	/* ── Home bar ── */
 	.home-bar {
 		border-top: 1px solid #f0ece4;
 		padding: 0.75rem 2rem;
+	}
+
+	.dark .home-bar {
+		border-top-color: rgba(255, 255, 255, 0.1);
 	}
 
 	.home-btn {
@@ -124,7 +196,15 @@
 		letter-spacing: 0.01em;
 	}
 
+	.dark .home-btn {
+		color: rgba(255, 255, 255, 0.35);
+	}
+
 	.home-btn:hover {
 		color: #1a1a1a;
+	}
+
+	.dark .home-btn:hover {
+		color: rgba(255, 255, 255, 0.88);
 	}
 </style>

--- a/src/lib/components/Frame.svelte
+++ b/src/lib/components/Frame.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import type { Snippet } from 'svelte';
+	import { locked, navigateFn } from '$lib/stores/canvas';
 
 	let {
 		id,
@@ -29,6 +30,11 @@
 
 <div {id} class="frame" style="left: {x}px; top: {y}px; {width ? `width: ${width}px;` : ''}">
 	{@render children()}
+	{#if $locked && id !== 'about'}
+		<div class="home-bar">
+			<button class="home-btn" onclick={() => $navigateFn?.('about')}>← Home</button>
+		</div>
+	{/if}
 </div>
 
 <style>
@@ -51,5 +57,27 @@
 		text-transform: uppercase;
 		pointer-events: none;
 		user-select: none;
+	}
+
+	.home-bar {
+		border-top: 1px solid #f0ece4;
+		padding: 0.75rem 2rem;
+	}
+
+	.home-btn {
+		background: none;
+		border: none;
+		padding: 0;
+		font-family: Montserrat, sans-serif;
+		font-size: 0.8rem;
+		font-weight: 600;
+		color: #aaa;
+		cursor: pointer;
+		transition: color 0.15s ease;
+		letter-spacing: 0.01em;
+	}
+
+	.home-btn:hover {
+		color: #1a1a1a;
 	}
 </style>

--- a/src/lib/components/Frame.svelte
+++ b/src/lib/components/Frame.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import type { Snippet } from 'svelte';
-	import { locked, navigateFn } from '$lib/stores/canvas';
+	import { locked, navigateFn, activeSection } from '$lib/stores/canvas';
 
 	let {
 		id,
@@ -17,6 +17,8 @@
 		label?: string;
 		children: Snippet;
 	} = $props();
+
+	let isRevealed = $derived(id === 'about' || $activeSection === id);
 </script>
 
 {#if label}
@@ -29,11 +31,18 @@
 {/if}
 
 <div {id} class="frame" style="left: {x}px; top: {y}px; {width ? `width: ${width}px;` : ''}">
-	{@render children()}
-	{#if $locked && id !== 'about'}
-		<div class="home-bar">
-			<button class="home-btn" onclick={() => $navigateFn?.('about')}>← Home</button>
-		</div>
+	{#if isRevealed}
+		{@render children()}
+		{#if $locked && id !== 'about'}
+			<div class="home-bar">
+				<button class="home-btn" onclick={() => $navigateFn?.('about')}>← Home</button>
+			</div>
+		{/if}
+	{:else}
+		<button class="preview" onclick={() => $navigateFn?.(id ?? '')}>
+			<span class="preview-label">{label}</span>
+			<span class="preview-hint">enter →</span>
+		</button>
 	{/if}
 </div>
 
@@ -59,6 +68,45 @@
 		user-select: none;
 	}
 
+	.preview {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		gap: 0.6rem;
+		width: 100%;
+		min-height: 130px;
+		background: none;
+		border: none;
+		border-radius: 8px;
+		padding: 2.5rem;
+		transition: background 0.15s ease;
+	}
+
+	.preview:hover {
+		background: #faf8f4;
+	}
+
+	.preview-label {
+		font-family: Montserrat, sans-serif;
+		font-size: 1.1rem;
+		font-weight: 700;
+		color: #1a1a1a;
+		letter-spacing: -0.02em;
+	}
+
+	.preview-hint {
+		font-family: Montserrat, sans-serif;
+		font-size: 0.75rem;
+		color: #bbb;
+		letter-spacing: 0.04em;
+		transition: color 0.15s ease;
+	}
+
+	.preview:hover .preview-hint {
+		color: #888;
+	}
+
 	.home-bar {
 		border-top: 1px solid #f0ece4;
 		padding: 0.75rem 2rem;
@@ -72,7 +120,6 @@
 		font-size: 0.8rem;
 		font-weight: 600;
 		color: #aaa;
-		cursor: pointer;
 		transition: color 0.15s ease;
 		letter-spacing: 0.01em;
 	}

--- a/src/lib/components/Frame.svelte
+++ b/src/lib/components/Frame.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
-	import type { Snippet } from 'svelte';
-	import { locked, navigateFn, activeSection } from '$lib/stores/canvas';
+	import { navigateFn } from '$lib/stores/canvas';
 
 	let {
 		id,
@@ -8,88 +7,43 @@
 		y,
 		width,
 		label,
-		fixed = false,
 		dark = false,
-		background,
-		children
+		background
 	}: {
 		id?: string;
 		x: number;
 		y: number;
 		width?: number;
 		label?: string;
-		fixed?: boolean;
 		dark?: boolean;
 		background?: string;
-		children: Snippet;
 	} = $props();
-
-	let isRevealed = $derived(id === 'about' || $activeSection === id);
 </script>
 
-{#if fixed}
-	<!-- Full-screen overlay for the about/landing frame -->
+{#if label}
 	<div
-		{id}
-		class="frame-fullscreen"
-		class:hiding={$locked}
-		style={background ? `background: ${background};` : ''}
+		class="frame-label"
+		style="left: {x}px; top: {y - 22}px; {width ? `width: ${width}px;` : ''}"
 	>
-		{@render children()}
-	</div>
-{:else}
-	{#if label}
-		<div
-			class="frame-label"
-			style="left: {x}px; top: {y - 22}px; {width ? `width: ${width}px;` : ''}"
-		>
-			{label}
-		</div>
-	{/if}
-
-	<div
-		{id}
-		class="frame"
-		class:dark
-		style="left: {x}px; top: {y}px; {width ? `width: ${width}px;` : ''}{background ? ` background: ${background};` : ''}"
-	>
-		{#if isRevealed}
-			{@render children()}
-			{#if $locked && id !== 'about'}
-				<div class="home-bar">
-					<button class="home-btn" onclick={() => $navigateFn?.('about')}>← Home</button>
-				</div>
-			{/if}
-		{:else}
-			<button class="preview" onclick={() => $navigateFn?.(id ?? '')}>
-				<span class="preview-label">{label}</span>
-				<span class="preview-hint">enter →</span>
-			</button>
-		{/if}
+		{label}
 	</div>
 {/if}
 
+<div
+	{id}
+	class="frame"
+	class:dark
+	style="left: {x}px; top: {y}px; {width ? `width: ${width}px;` : ''}{background
+		? ` background: ${background};`
+		: ''}"
+>
+	<button class="preview" onclick={() => $navigateFn?.(id ?? '')}>
+		<span class="preview-label">{label}</span>
+		<span class="preview-hint">enter →</span>
+	</button>
+</div>
+
 <style>
-	/* ── Fixed full-screen frame (About / landing) ── */
-	.frame-fullscreen {
-		position: fixed;
-		inset: 0;
-		z-index: 50;
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		background: #f8f6f1;
-		opacity: 1;
-		pointer-events: auto;
-		transition: opacity 0.35s ease;
-	}
-
-	.frame-fullscreen.hiding {
-		opacity: 0;
-		pointer-events: none;
-	}
-
-	/* ── Canvas card frame ── */
 	.frame {
 		position: absolute;
 		background: #fff;
@@ -118,7 +72,6 @@
 		user-select: none;
 	}
 
-	/* ── Preview gateway button ── */
 	.preview {
 		display: flex;
 		flex-direction: column;
@@ -172,39 +125,5 @@
 
 	.dark .preview:hover .preview-hint {
 		color: rgba(255, 255, 255, 0.6);
-	}
-
-	/* ── Home bar ── */
-	.home-bar {
-		border-top: 1px solid #f0ece4;
-		padding: 0.75rem 2rem;
-	}
-
-	.dark .home-bar {
-		border-top-color: rgba(255, 255, 255, 0.1);
-	}
-
-	.home-btn {
-		background: none;
-		border: none;
-		padding: 0;
-		font-family: Montserrat, sans-serif;
-		font-size: 0.8rem;
-		font-weight: 600;
-		color: #aaa;
-		transition: color 0.15s ease;
-		letter-spacing: 0.01em;
-	}
-
-	.dark .home-btn {
-		color: rgba(255, 255, 255, 0.35);
-	}
-
-	.home-btn:hover {
-		color: #1a1a1a;
-	}
-
-	.dark .home-btn:hover {
-		color: rgba(255, 255, 255, 0.88);
 	}
 </style>

--- a/src/lib/components/Header.svelte
+++ b/src/lib/components/Header.svelte
@@ -2,10 +2,10 @@
 	import { navigateFn } from '$lib/stores/canvas';
 
 	const navItems = [
-		{ label: 'About', id: 'about' },
-		{ label: 'Work', id: 'portfolio' },
-		{ label: 'Garden', id: 'garden' },
-		{ label: 'Links', id: 'links' }
+		{ id: 'about',     shape: 'circle'   },
+		{ id: 'portfolio', shape: 'square'   },
+		{ id: 'garden',    shape: 'triangle' },
+		{ id: 'links',     shape: 'diamond'  },
 	];
 
 	function navigate(id: string) {
@@ -17,7 +17,17 @@
 	<div class="name">marcus lee</div>
 	<nav>
 		{#each navItems as item}
-			<button onclick={() => navigate(item.id)}>{item.label}</button>
+			<button onclick={() => navigate(item.id)} aria-label={item.id}>
+				{#if item.shape === 'circle'}
+					<svg viewBox="0 0 14 14" fill="currentColor"><circle cx="7" cy="7" r="6"/></svg>
+				{:else if item.shape === 'square'}
+					<svg viewBox="0 0 14 14" fill="currentColor"><rect x="1" y="1" width="12" height="12"/></svg>
+				{:else if item.shape === 'triangle'}
+					<svg viewBox="0 0 14 14" fill="currentColor"><polygon points="7,1 13,13 1,13"/></svg>
+				{:else if item.shape === 'diamond'}
+					<svg viewBox="0 0 14 14" fill="currentColor"><polygon points="7,1 13,7 7,13 1,7"/></svg>
+				{/if}
+			</button>
 		{/each}
 	</nav>
 </header>
@@ -49,24 +59,33 @@
 	}
 
 	nav {
+		position: absolute;
+		left: 50%;
+		transform: translateX(-50%);
 		display: flex;
-		gap: 24px;
+		gap: 20px;
 		align-items: center;
 	}
 
 	nav button {
-		font-family: Montserrat, sans-serif;
-		font-size: 12px;
-		color: #777;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 20px;
+		height: 20px;
 		background: none;
 		border: none;
-		cursor: pointer;
-		padding: 4px 0;
+		padding: 0;
+		color: #bbb;
 		transition: color 0.15s ease;
-		letter-spacing: 0.02em;
 	}
 
 	nav button:hover {
 		color: #1a1a1a;
+	}
+
+	nav button svg {
+		width: 10px;
+		height: 10px;
 	}
 </style>

--- a/src/lib/components/Portfolio.svelte
+++ b/src/lib/components/Portfolio.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-  import { navigateFn } from '$lib/stores/canvas';
-
   export type Work = {
     category: CATEGORY;
     title: string;
@@ -13,131 +11,102 @@
   let { works }: { works: Work[] } = $props();
 </script>
 
-<div class="portfolio">
-  <div class="header-row">
-    <h2 class="heading">Work</h2>
-    <button class="back-btn" onclick={() => $navigateFn?.('about')}>← Back to about</button>
-  </div>
-  <div class="container">
-    {#each works as work}
-      <div class="project">
-        <a target="_blank" rel="noopener noreferrer" href={work.link}>
-          <img src={work.img} alt={work.title} />
-          <div class="overlay">
-            <div class="text-content">
-              <h3 class="title">{work.title}</h3>
-              <p class="description">{work.description}</p>
-            </div>
-          </div>
-        </a>
-      </div>
-    {/each}
-  </div>
-</div>
+{#each works as work}
+  <a
+    class="panel"
+    href={work.link}
+    target="_blank"
+    rel="noopener noreferrer"
+  >
+    <div class="panel-image">
+      <img src={work.img} alt={work.title} />
+    </div>
+    <div class="panel-info">
+      <p class="category">{work.category}</p>
+      <h3 class="title">{work.title}</h3>
+      <p class="desc">{work.description}</p>
+      <span class="visit">visit →</span>
+    </div>
+  </a>
+{/each}
 
 <style>
-  .portfolio {
-    padding: 2rem 2rem 2.5rem;
-    font-family: Montserrat, sans-serif;
-  }
-
-  .header-row {
+  .panel {
     display: flex;
-    align-items: baseline;
-    justify-content: space-between;
-    margin-bottom: 1.25rem;
-  }
-
-  .heading {
-    font-size: 1.5rem;
-    font-weight: 700;
-    color: #1a1a1a;
-    margin: 0;
-    letter-spacing: -0.02em;
-  }
-
-  .back-btn {
-    background: none;
-    border: none;
-    padding: 0;
-    font-family: Montserrat, sans-serif;
-    font-size: 0.8rem;
-    font-weight: 600;
-    color: #888;
-    cursor: pointer;
-    transition: color 0.15s ease;
-    letter-spacing: 0.01em;
-  }
-
-  .back-btn:hover {
-    color: #1a1a1a;
-  }
-
-  .container {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 0.75rem;
-    width: 100%;
-  }
-
-  .project {
-    position: relative;
-    width: 100%;
-    aspect-ratio: 16 / 9;
+    flex-direction: column;
+    flex-shrink: 0;
+    width: max(340px, 32vw);
+    height: 100%;
+    text-decoration: none;
+    scroll-snap-align: start;
+    border-right: 1px solid #e0dbd3;
     overflow: hidden;
-    cursor: pointer;
-    transition: transform 0.3s ease;
+    transition: background 0.2s ease;
   }
 
-  .project:hover {
-    transform: scale(1.02);
+  .panel:hover {
+    background: #ebe8e2;
   }
 
-  .project img {
+  .panel-image {
+    flex: 0 0 55%;
+    overflow: hidden;
+  }
+
+  .panel-image img {
     width: 100%;
     height: 100%;
     object-fit: cover;
-    transition: filter 0.3s ease;
+    transition: transform 0.4s ease, filter 0.3s ease;
   }
 
-  .project:hover img {
-    filter: brightness(0.4) grayscale(0.3);
+  .panel:hover .panel-image img {
+    transform: scale(1.04);
+    filter: brightness(0.92);
   }
 
-  .overlay {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
+  .panel-info {
+    flex: 1;
+    padding: 1.75rem 2rem;
     display: flex;
-    align-items: center;
+    flex-direction: column;
     justify-content: center;
-    opacity: 0;
-    transition: opacity 0.3s ease;
-    background: rgba(0, 0, 0, 0.1);
+    font-family: Montserrat, sans-serif;
   }
 
-  .project:hover .overlay {
-    opacity: 1;
-  }
-
-  .text-content {
-    text-align: center;
-    color: rgb(209, 209, 209);
-    padding: 1rem;
-    max-width: 90%;
+  .category {
+    font-size: 0.7rem;
+    color: #aaa;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    margin: 0 0 0.5rem;
   }
 
   .title {
-    font-size: 1.1rem;
-    font-weight: bold;
-    margin: 0 0 0.5rem 0;
+    font-size: 1.15rem;
+    font-weight: 700;
+    color: #1a1a1a;
+    margin: 0 0 0.6rem;
+    letter-spacing: -0.02em;
+    line-height: 1.25;
   }
 
-  .description {
-    font-size: 0.85rem;
-    margin: 0;
-    line-height: 1.4;
+  .desc {
+    font-size: 0.82rem;
+    color: #777;
+    margin: 0 0 1.25rem;
+    line-height: 1.7;
+  }
+
+  .visit {
+    font-size: 0.78rem;
+    font-weight: 600;
+    color: #aaa;
+    letter-spacing: 0.04em;
+    transition: color 0.15s ease;
+  }
+
+  .panel:hover .visit {
+    color: #1a1a1a;
   }
 </style>

--- a/src/lib/components/Portfolio.svelte
+++ b/src/lib/components/Portfolio.svelte
@@ -1,98 +1,143 @@
-<script lang='ts'>
-    let {works}: {works: Work[]} = $props();
-    export type Work = {
-        category: CATEGORY,
-        title: string;
-        img: string,
-        description: string,
-        link: string
-    }
-    type CATEGORY = "Professional Experience" | "Project"
+<script lang="ts">
+  import { navigateFn } from '$lib/stores/canvas';
+
+  export type Work = {
+    category: CATEGORY;
+    title: string;
+    img: string;
+    description: string;
+    link: string;
+  };
+  type CATEGORY = 'Professional Experience' | 'Project';
+
+  let { works }: { works: Work[] } = $props();
 </script>
-    
-    <div class="container">
-        {#each works as work}
-        <div class='project'>
-            <a target="_blank" rel="noopener noref" href={work.link}>
-                <img src={work.img} alt={work.title}>
-                <div class="overlay">
-                    <div class="text-content">
-                        <h3 class="title">{work.title}</h3>
-                        <p class="description">{work.description}</p>
-                    </div>
-                </div>
-            </a>
-        </div>
-        {/each}
-    </div>
-    
-    <style>
-    .container {
-        font-family: Montserrat, Arial;
-        display: grid;
-        grid-template-columns: 1fr 1fr; /* Fixed 2 columns */
-        gap: 1rem;
-        width: 100%;
-    }
-    
-    .project {
-        position: relative;
-        width: 100%;
-        aspect-ratio: 16 / 9; /* Maintains a 16:9 ratio */
-        overflow: hidden;
-        cursor: pointer;
-        transition: transform 0.3s ease;
-    }
-    
-    .project:hover {
-        transform: scale(1.02);
-    }
-    
-    .project img {
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-        transition: filter 0.3s ease;
-    }
-    
-    .project:hover img {
-        filter: brightness(0.4) grayscale(0.3);
-    }
-    
-    .overlay {
-        position: absolute;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        opacity: 0;
-        transition: opacity 0.3s ease;
-        background: rgba(0, 0, 0, 0.1);
-    }
-    
-    .project:hover .overlay {
-        opacity: 1;
-    }
-    
-    .text-content {
-        text-align: center;
-        color: rgb(209, 209, 209);
-        padding: 1rem;
-        max-width: 90%;
-    }
-    
-    .title {
-        font-size: 1.25rem;
-        font-weight: bold;
-        margin: 0 0 0.5rem 0;
-    }
-    
-    .description {
-        font-size: 0.9rem;
-        margin: 0;
-        line-height: 1.4;
-    }
-    </style>
+
+<div class="portfolio">
+  <div class="header-row">
+    <h2 class="heading">Work</h2>
+    <button class="back-btn" onclick={() => $navigateFn?.('about')}>← Back to about</button>
+  </div>
+  <div class="container">
+    {#each works as work}
+      <div class="project">
+        <a target="_blank" rel="noopener noreferrer" href={work.link}>
+          <img src={work.img} alt={work.title} />
+          <div class="overlay">
+            <div class="text-content">
+              <h3 class="title">{work.title}</h3>
+              <p class="description">{work.description}</p>
+            </div>
+          </div>
+        </a>
+      </div>
+    {/each}
+  </div>
+</div>
+
+<style>
+  .portfolio {
+    padding: 2rem 2rem 2.5rem;
+    font-family: Montserrat, sans-serif;
+  }
+
+  .header-row {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    margin-bottom: 1.25rem;
+  }
+
+  .heading {
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: #1a1a1a;
+    margin: 0;
+    letter-spacing: -0.02em;
+  }
+
+  .back-btn {
+    background: none;
+    border: none;
+    padding: 0;
+    font-family: Montserrat, sans-serif;
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: #888;
+    cursor: pointer;
+    transition: color 0.15s ease;
+    letter-spacing: 0.01em;
+  }
+
+  .back-btn:hover {
+    color: #1a1a1a;
+  }
+
+  .container {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.75rem;
+    width: 100%;
+  }
+
+  .project {
+    position: relative;
+    width: 100%;
+    aspect-ratio: 16 / 9;
+    overflow: hidden;
+    cursor: pointer;
+    transition: transform 0.3s ease;
+  }
+
+  .project:hover {
+    transform: scale(1.02);
+  }
+
+  .project img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    transition: filter 0.3s ease;
+  }
+
+  .project:hover img {
+    filter: brightness(0.4) grayscale(0.3);
+  }
+
+  .overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    opacity: 0;
+    transition: opacity 0.3s ease;
+    background: rgba(0, 0, 0, 0.1);
+  }
+
+  .project:hover .overlay {
+    opacity: 1;
+  }
+
+  .text-content {
+    text-align: center;
+    color: rgb(209, 209, 209);
+    padding: 1rem;
+    max-width: 90%;
+  }
+
+  .title {
+    font-size: 1.1rem;
+    font-weight: bold;
+    margin: 0 0 0.5rem 0;
+  }
+
+  .description {
+    font-size: 0.85rem;
+    margin: 0;
+    line-height: 1.4;
+  }
+</style>

--- a/src/lib/stores/canvas.ts
+++ b/src/lib/stores/canvas.ts
@@ -2,3 +2,4 @@ import { writable } from 'svelte/store';
 
 export const navigateFn = writable<((id: string) => void) | null>(null);
 export const locked = writable(false);
+export const activeSection = writable<string | null>(null);

--- a/src/lib/stores/canvas.ts
+++ b/src/lib/stores/canvas.ts
@@ -1,3 +1,4 @@
 import { writable } from 'svelte/store';
 
 export const navigateFn = writable<((id: string) => void) | null>(null);
+export const locked = writable(false);

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+  import '../app.css';
+  import type { Snippet } from 'svelte';
+  let { children }: { children: Snippet } = $props();
+</script>
+{@render children()}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -94,13 +94,12 @@
     justify-content: center;
     background: #f8f6f1;
     opacity: 1;
-    pointer-events: auto;
+    pointer-events: none; /* pass drags through to canvas */
     transition: opacity 0.35s ease;
   }
 
   .about-overlay.hiding {
     opacity: 0;
-    pointer-events: none;
   }
 
   /* ── Section overlays ── */

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -19,19 +19,19 @@
 
 <Header />
 <Canvas {framePositions}>
-  <Frame id="about"     x={framePositions.about.x}     y={framePositions.about.y}     width={framePositions.about.width}     label="About">
+  <Frame id="about" fixed x={framePositions.about.x} y={framePositions.about.y} width={framePositions.about.width}>
     <Bio />
   </Frame>
-  <Frame id="portfolio" x={framePositions.portfolio.x} y={framePositions.portfolio.y} width={framePositions.portfolio.width} label="Work">
+  <Frame id="portfolio" x={framePositions.portfolio.x} y={framePositions.portfolio.y} width={framePositions.portfolio.width} label="Work" background="#f0ede8">
     <Portfolio works={data.works} />
   </Frame>
-  <Frame id="garden"    x={framePositions.garden.x}    y={framePositions.garden.y}    width={framePositions.garden.width}    label="Garden">
-    <div class="placeholder">
+  <Frame id="garden" x={framePositions.garden.x} y={framePositions.garden.y} width={framePositions.garden.width} label="Garden" background="#1a3a26" dark>
+    <div class="placeholder dark">
       <h2>Garden</h2>
       <p>Writing and notes — coming soon.</p>
     </div>
   </Frame>
-  <Frame id="links"     x={framePositions.links.x}     y={framePositions.links.y}     width={framePositions.links.width}     label="Links">
+  <Frame id="links" x={framePositions.links.x} y={framePositions.links.y} width={framePositions.links.width} label="Links">
     <div class="placeholder">
       <h2>Links</h2>
       <ul>
@@ -51,4 +51,8 @@
   .placeholder ul li { margin: 0.75rem 0; }
   .placeholder ul li a { font-size: 0.9rem; color: #555; text-decoration: none; border-bottom: 1px solid #e0dbd3; padding-bottom: 1px; transition: color 0.15s ease, border-color 0.15s ease; }
   .placeholder ul li a:hover { color: #1a1a1a; border-color: #1a1a1a; }
+
+  /* Dark theme overrides for garden */
+  .placeholder.dark h2 { color: rgba(220, 255, 220, 0.9); }
+  .placeholder.dark p { color: rgba(180, 220, 180, 0.6); }
 </style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -12,7 +12,7 @@
   const framePositions = {
     about:     { x: -300, y: -200, width: 600, height: 400 },
     portfolio: { x: 1100, y: -250, width: 740, height: 650 },
-    garden:    { x: -300, y: -1400, width: 600, height: 400 },
+    garden:    { x: -300, y:  350,  width: 600, height: 400 },
     links:     { x: -1700, y: -200, width: 480, height: 380 },
   };
 </script>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,21 +1,54 @@
-<script lang='ts'>
-  import Bio from "$lib/components/Bio.svelte";
-  import Portfolio from "$lib/components/Portfolio.svelte";
-  import type { PageProps } from "./$types";
-  let {data}: PageProps = $props();
+<script lang="ts">
+  import Canvas from '$lib/components/Canvas.svelte';
+  import Frame from '$lib/components/Frame.svelte';
+  import Header from '$lib/components/Header.svelte';
+  import Bio from '$lib/components/Bio.svelte';
+  import Portfolio from '$lib/components/Portfolio.svelte';
+  import type { PageProps } from './$types';
+
+  let { data }: PageProps = $props();
+
+  // height is an estimate used only for centering on navigate
+  const framePositions = {
+    about:     { x: -300, y: -200, width: 600, height: 400 },
+    portfolio: { x: 1100, y: -250, width: 740, height: 650 },
+    garden:    { x: -300, y: -1400, width: 600, height: 400 },
+    links:     { x: -1700, y: -200, width: 480, height: 380 },
+  };
 </script>
 
-<div class="frame">
-  <Bio/>
-  <Portfolio works={data.works}/>
-</div>
+<Header />
+<Canvas {framePositions}>
+  <Frame id="about"     x={framePositions.about.x}     y={framePositions.about.y}     width={framePositions.about.width}     label="About">
+    <Bio />
+  </Frame>
+  <Frame id="portfolio" x={framePositions.portfolio.x} y={framePositions.portfolio.y} width={framePositions.portfolio.width} label="Work">
+    <Portfolio works={data.works} />
+  </Frame>
+  <Frame id="garden"    x={framePositions.garden.x}    y={framePositions.garden.y}    width={framePositions.garden.width}    label="Garden">
+    <div class="placeholder">
+      <h2>Garden</h2>
+      <p>Writing and notes — coming soon.</p>
+    </div>
+  </Frame>
+  <Frame id="links"     x={framePositions.links.x}     y={framePositions.links.y}     width={framePositions.links.width}     label="Links">
+    <div class="placeholder">
+      <h2>Links</h2>
+      <ul>
+        <li><a target="_blank" rel="noopener noreferrer" href="https://www.linkedin.com/in/marcusnglee">LinkedIn</a></li>
+        <li><a target="_blank" rel="noopener noreferrer" href="https://www.github.com/marcusnglee">GitHub</a></li>
+        <li><a target="_blank" rel="noopener noreferrer" href="https://medium.com/design-bootcamp/we-love-automation-but-hate-ai-what-ux-teaches-us-about-control-and-trust-c2f41c29906b">Medium</a></li>
+      </ul>
+    </div>
+  </Frame>
+</Canvas>
 
 <style>
-  :global(body) {
-    background-color: rgb(248, 248, 248);
-  }
-  .frame {
-    padding: 4rem 16rem;
-  }
-  
+  .placeholder { padding: 2.5rem; font-family: Montserrat, sans-serif; }
+  .placeholder h2 { font-size: 1.5rem; font-weight: 700; color: #1a1a1a; margin: 0 0 1rem; letter-spacing: -0.02em; }
+  .placeholder p { font-size: 0.9rem; color: #888; margin: 0; line-height: 1.7; }
+  .placeholder ul { list-style: none; padding: 0; margin: 0; }
+  .placeholder ul li { margin: 0.75rem 0; }
+  .placeholder ul li a { font-size: 0.9rem; color: #555; text-decoration: none; border-bottom: 1px solid #e0dbd3; padding-bottom: 1px; transition: color 0.15s ease, border-color 0.15s ease; }
+  .placeholder ul li a:hover { color: #1a1a1a; border-color: #1a1a1a; }
 </style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
+  import { fade } from 'svelte/transition';
   import Canvas from '$lib/components/Canvas.svelte';
   import Frame from '$lib/components/Frame.svelte';
   import Header from '$lib/components/Header.svelte';
   import Bio from '$lib/components/Bio.svelte';
   import Portfolio from '$lib/components/Portfolio.svelte';
+  import { locked, activeSection, navigateFn } from '$lib/stores/canvas';
   import type { PageProps } from './$types';
 
   let { data }: PageProps = $props();
@@ -12,47 +14,207 @@
   const framePositions = {
     about:     { x: -300, y: -200, width: 600, height: 400 },
     portfolio: { x: 1100, y: -250, width: 740, height: 650 },
-    garden:    { x: -300, y:  350,  width: 600, height: 400 },
+    garden:    { x: -300, y:  350, width: 600, height: 400 },
     links:     { x: -1700, y: -200, width: 480, height: 380 },
   };
+
+  // Convert vertical wheel to horizontal scroll on section panels
+  function hscroll(node: HTMLElement) {
+    function handler(e: WheelEvent) {
+      e.preventDefault();
+      node.scrollLeft += e.deltaY + e.deltaX;
+    }
+    node.addEventListener('wheel', handler, { passive: false });
+    return { destroy() { node.removeEventListener('wheel', handler); } };
+  }
 </script>
 
 <Header />
+
+<!-- ── About overlay ─────────────────────────────────────────── -->
+<!-- Rendered outside canvas so position:fixed isn't inside a transform context -->
+<div class="about-overlay" class:hiding={$locked}>
+  <Bio />
+</div>
+
+<!-- ── Section overlays ──────────────────────────────────────── -->
+
+{#if $activeSection === 'portfolio'}
+  <div class="section-overlay" style="background: #f0ede8;" transition:fade={{ duration: 280, delay: 60 }}>
+    <div class="section-scroll" use:hscroll>
+      <Portfolio works={data.works} />
+    </div>
+    <button class="home-btn" onclick={() => $navigateFn?.('about')}>← Home</button>
+  </div>
+{/if}
+
+{#if $activeSection === 'garden'}
+  <div class="section-overlay" style="background: #1a3a26;" transition:fade={{ duration: 280, delay: 60 }}>
+    <div class="section-scroll" use:hscroll>
+      <div class="section-panel dark">
+        <h2>Garden</h2>
+        <p>Writing and notes — coming soon.</p>
+      </div>
+    </div>
+    <button class="home-btn dark" onclick={() => $navigateFn?.('about')}>← Home</button>
+  </div>
+{/if}
+
+{#if $activeSection === 'links'}
+  <div class="section-overlay" transition:fade={{ duration: 280, delay: 60 }}>
+    <div class="section-scroll" use:hscroll>
+      <div class="section-panel">
+        <h2>Links</h2>
+        <ul>
+          <li><a target="_blank" rel="noopener noreferrer" href="https://www.linkedin.com/in/marcusnglee">LinkedIn</a></li>
+          <li><a target="_blank" rel="noopener noreferrer" href="https://www.github.com/marcusnglee">GitHub</a></li>
+          <li><a target="_blank" rel="noopener noreferrer" href="https://medium.com/design-bootcamp/we-love-automation-but-hate-ai-what-ux-teaches-us-about-control-and-trust-c2f41c29906b">Medium</a></li>
+        </ul>
+      </div>
+    </div>
+    <button class="home-btn" onclick={() => $navigateFn?.('about')}>← Home</button>
+  </div>
+{/if}
+
+<!-- ── Canvas: zoom animation + preview cards only ───────────── -->
 <Canvas {framePositions}>
-  <Frame id="about" fixed x={framePositions.about.x} y={framePositions.about.y} width={framePositions.about.width}>
-    <Bio />
-  </Frame>
-  <Frame id="portfolio" x={framePositions.portfolio.x} y={framePositions.portfolio.y} width={framePositions.portfolio.width} label="Work" background="#f0ede8">
-    <Portfolio works={data.works} />
-  </Frame>
-  <Frame id="garden" x={framePositions.garden.x} y={framePositions.garden.y} width={framePositions.garden.width} label="Garden" background="#1a3a26" dark>
-    <div class="placeholder dark">
-      <h2>Garden</h2>
-      <p>Writing and notes — coming soon.</p>
-    </div>
-  </Frame>
-  <Frame id="links" x={framePositions.links.x} y={framePositions.links.y} width={framePositions.links.width} label="Links">
-    <div class="placeholder">
-      <h2>Links</h2>
-      <ul>
-        <li><a target="_blank" rel="noopener noreferrer" href="https://www.linkedin.com/in/marcusnglee">LinkedIn</a></li>
-        <li><a target="_blank" rel="noopener noreferrer" href="https://www.github.com/marcusnglee">GitHub</a></li>
-        <li><a target="_blank" rel="noopener noreferrer" href="https://medium.com/design-bootcamp/we-love-automation-but-hate-ai-what-ux-teaches-us-about-control-and-trust-c2f41c29906b">Medium</a></li>
-      </ul>
-    </div>
-  </Frame>
+  <Frame id="portfolio" x={framePositions.portfolio.x} y={framePositions.portfolio.y} width={framePositions.portfolio.width} label="Work"   background="#f0ede8" />
+  <Frame id="garden"    x={framePositions.garden.x}    y={framePositions.garden.y}    width={framePositions.garden.width}    label="Garden" background="#1a3a26" dark />
+  <Frame id="links"     x={framePositions.links.x}     y={framePositions.links.y}     width={framePositions.links.width}     label="Links" />
 </Canvas>
 
 <style>
-  .placeholder { padding: 2.5rem; font-family: Montserrat, sans-serif; }
-  .placeholder h2 { font-size: 1.5rem; font-weight: 700; color: #1a1a1a; margin: 0 0 1rem; letter-spacing: -0.02em; }
-  .placeholder p { font-size: 0.9rem; color: #888; margin: 0; line-height: 1.7; }
-  .placeholder ul { list-style: none; padding: 0; margin: 0; }
-  .placeholder ul li { margin: 0.75rem 0; }
-  .placeholder ul li a { font-size: 0.9rem; color: #555; text-decoration: none; border-bottom: 1px solid #e0dbd3; padding-bottom: 1px; transition: color 0.15s ease, border-color 0.15s ease; }
-  .placeholder ul li a:hover { color: #1a1a1a; border-color: #1a1a1a; }
+  /* ── About overlay ── */
+  .about-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 50;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: #f8f6f1;
+    opacity: 1;
+    pointer-events: auto;
+    transition: opacity 0.35s ease;
+  }
 
-  /* Dark theme overrides for garden */
-  .placeholder.dark h2 { color: rgba(220, 255, 220, 0.9); }
-  .placeholder.dark p { color: rgba(180, 220, 180, 0.6); }
+  .about-overlay.hiding {
+    opacity: 0;
+    pointer-events: none;
+  }
+
+  /* ── Section overlays ── */
+  .section-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 50;
+    background: #fff;
+    overflow: hidden;
+  }
+
+  .section-scroll {
+    display: flex;
+    flex-direction: row;
+    height: 100%;
+    overflow-x: auto;
+    overflow-y: hidden;
+    scroll-snap-type: x mandatory;
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+    padding-top: 44px; /* clear the header */
+  }
+
+  .section-scroll::-webkit-scrollbar {
+    display: none;
+  }
+
+  /* Single-panel sections (garden, links) */
+  .section-panel {
+    flex-shrink: 0;
+    width: 100vw;
+    height: 100%;
+    scroll-snap-align: start;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    padding: 4rem 6rem;
+    font-family: Montserrat, sans-serif;
+  }
+
+  .section-panel h2 {
+    font-size: 2rem;
+    font-weight: 700;
+    color: #1a1a1a;
+    margin: 0 0 1rem;
+    letter-spacing: -0.03em;
+  }
+
+  .section-panel p {
+    font-size: 0.9rem;
+    color: #888;
+    margin: 0;
+    line-height: 1.8;
+  }
+
+  .section-panel ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+
+  .section-panel ul li {
+    margin: 0.75rem 0;
+  }
+
+  .section-panel ul li a {
+    font-size: 0.95rem;
+    color: #555;
+    text-decoration: none;
+    border-bottom: 1px solid #e0dbd3;
+    padding-bottom: 1px;
+    transition: color 0.15s ease, border-color 0.15s ease;
+  }
+
+  .section-panel ul li a:hover {
+    color: #1a1a1a;
+    border-color: #1a1a1a;
+  }
+
+  /* Dark variant (garden) */
+  .section-panel.dark h2 {
+    color: rgba(220, 255, 220, 0.9);
+  }
+
+  .section-panel.dark p {
+    color: rgba(180, 220, 180, 0.6);
+  }
+
+  /* ── Home button (floating bottom-left) ── */
+  .home-btn {
+    position: absolute;
+    bottom: 1.5rem;
+    left: 1.75rem;
+    background: none;
+    border: none;
+    padding: 0;
+    font-family: Montserrat, sans-serif;
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: #aaa;
+    letter-spacing: 0.01em;
+    transition: color 0.15s ease;
+    z-index: 1;
+  }
+
+  .home-btn:hover {
+    color: #1a1a1a;
+  }
+
+  .home-btn.dark {
+    color: rgba(255, 255, 255, 0.35);
+  }
+
+  .home-btn.dark:hover {
+    color: rgba(255, 255, 255, 0.88);
+  }
 </style>


### PR DESCRIPTION
## Summary
Completely redesigned the portfolio from a static grid layout into an **infinite canvas experience** with programmatic zoom navigation and full-screen section overlays. The canvas centers on an "about" frame on load; clicking section preview cards animates a zoom-to-fit transition and displays content in fixed overlays while locking canvas interaction.

## Key Changes

### Architecture
- **Canvas-based navigation**: Replaced static page layout with `Canvas.svelte` (infinite pan, programmatic zoom). Frame positions defined in `+page.svelte` as a config object.
- **Overlay system**: All overlays (`position: fixed`) rendered outside Canvas in `+page.svelte` to avoid transform context issues. About overlay always mounted (fades out when locked); section overlays conditionally rendered with `transition:fade`.
- **State management**: Added `locked` and `activeSection` stores to coordinate canvas lock/unlock and overlay visibility.

### Components
- **Canvas.svelte**: Removed manual zoom (ctrl+scroll, pinch). Zoom is now purely programmatic via `navigateTo()`. Respects `$locked` to disable drag when viewing sections.
- **Frame.svelte**: Simplified to render preview cards only (no children slots). Added `dark` variant and `background` prop. Preview button calls `navigateFn(id)` to trigger navigation.
- **Bio.svelte**: Redesigned as a centered card with name, tagline, body text, action buttons (→ Work, → Garden, → Links), and footer links. Removed 3rd-person description.
- **Portfolio.svelte**: Converted from 2-column grid to horizontal scroll panels. Each work item is a full-height card (image 55% / info 45%) with category, title, description, and "visit →" hint.
- **Header.svelte**: Replaced text labels with geometric shape icons (circle, square, triangle, diamond) centered in header. Positioned nav absolutely.

### Navigation Flow
1. On load, canvas centers on `about` frame (scale = 1).
2. Clicking a section preview card calls `navigateFn(id)`:
   - Animates scale to `min(vw/frameWidth, vh/frameHeight)` (500ms cubic-bezier).
   - Sets `locked = true` (disables canvas drag).
   - Sets `activeSection = id` (shows corresponding overlay).
3. Clicking "← Home" button resets to about (scale = 1, locked = false, activeSection = null).

### Styling & UX
- **Horizontal scroll**: Portfolio and other sections use `overflow-x: auto; scroll-snap-type: x mandatory`. Added `use:hscroll` action to convert vertical wheel events to horizontal scroll.
- **Color scheme**: Light background (#f8f6f1) for about/portfolio; dark (#1a3a26) for garden. Consistent typography (Montserrat), subtle borders, hover transitions.
- **Responsive**: Bio width uses `min(580px, calc(100vw - 5rem))` for mobile adaptation.

### Global
- Added `src/app.css` with global box-sizing and custom cursor.
- Added `src/routes/+layout.svelte` to import global styles.
- Updated `.gitignore` to include `.vercel`.

## Notable Implementation Details
- **Fixed overlay positioning**: All overlays are direct children of `+page.svelte` (not inside Canvas) because `position: fixed` inside a transformed element anchors to the transform context, not the viewport.
- **Pointer events**: About overlay has `pointer-events: none` on container but `pointer-events: auto` on `.bio` so canvas is pannable through the bio while buttons/links remain interactive.
- **Programmatic zoom only**: Removed user-initiated zoom (ctrl+scroll, pinch). Zoom is triggered only by navigation, simplifying interaction model.
- **Frame positions**: Defined as a single config object in `+page.svelte` for easy adjustment and passed to Canvas as a prop.

https://claude.ai/code/session_01QLeoDzYYUcbEJEjNT6T29C